### PR TITLE
added word-wrap to .brand-title

### DIFF
--- a/_sass/hydure/_sidebar.scss
+++ b/_sass/hydure/_sidebar.scss
@@ -27,6 +27,7 @@
   font-weight: bold;
   line-height: 1.2;
   letter-spacing: -1px;
+  word-wrap: break-word;
 }
 
 .brand-tagline {


### PR DESCRIPTION
Word Wrap on the title allows the heading to not spill outside the sidebar.
In some resolutions like the iPad resolution the Title was spilling out of the Sidebar
Example:
Without Word Wrap
![image](https://user-images.githubusercontent.com/63702654/126514593-5916fd0a-fdea-4f36-bfc1-191f559a51e7.png)

With Word Wrap
![image](https://user-images.githubusercontent.com/63702654/126514716-7315c040-493d-4bf9-9256-b28192e9e96c.png)

Edit:
I have only made change on the main branch and not the gh-pages branch